### PR TITLE
簡易flatpickrカレンダーアプリに必要なアプリを作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+.DS_Store
+/vendor/bundle
+/.idea

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -1,0 +1,10 @@
+class CalendarsController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -1,0 +1,2 @@
+class Calendar < ApplicationRecord
+end

--- a/app/views/calendars/create.html.erb
+++ b/app/views/calendars/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Calendars#create</h1>
+<p>Find me in app/views/calendars/create.html.erb</p>

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Calendars#index</h1>
+<p>Find me in app/views/calendars/index.html.erb</p>

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Calendars#new</h1>
+<p>Find me in app/views/calendars/new.html.erb</p>

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,0 +1,6 @@
+Rails.application.config.generators do |g|
+  g.skip_routes true
+  g.assets false
+  g.helper false
+  g.test_framework false
+end

--- a/db/migrate/20210212041036_create_calendars.rb
+++ b/db/migrate/20210212041036_create_calendars.rb
@@ -1,0 +1,9 @@
+class CreateCalendars < ActiveRecord::Migration[6.0]
+  def change
+    create_table :calendars do |t|
+      t.date :date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_02_12_041036) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "calendars", force: :cascade do |t|
+    t.date "date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end


### PR DESCRIPTION
## 概要
- 簡易flatpickrカレンダーアプリに必要なアプリを作成
### 内容
- gitignoreに.DS_storeと/vendor/bundleを追加
- Calendarモデルとcalendarsテーブルを作成
- rails g controller コマンドで作成されるファイルを制限
- calendarsコントローラとビューファイルを作成